### PR TITLE
Load user defined css after the main template css

### DIFF
--- a/mxtheme/layout.html
+++ b/mxtheme/layout.html
@@ -11,12 +11,12 @@
 {% endblock %}
 
 
-{% set css_files = css_files + [
+{% set css_files = [
     '_static/material-design-lite-1.3.0/material.' + theme_primary_color|e + '-' + theme_accent_color|e + '.min.css',
     '_static/sphinx_materialdesign_theme.css',
     '_static/fontawesome/all.css',
     '_static/fonts.css',
-] %}
+] + css_files %}
 
     {%- block header %}
 	<script type="text/javascript" src="{{ pathto('_static/sphinx_materialdesign_theme.js', 1) }} "></script>


### PR DESCRIPTION
To enable customization of the main material design theme's css (for example to support RTL: example discussion https://github.com/d2l-ai/d2l-en/issues/670#issuecomment-570489486 ). The custom css should be loaded after the main theme's css.