### PR TITLE
mark mxtheme as safe for parallel read

### DIFF
--- a/mxtheme/__init__.py
+++ b/mxtheme/__init__.py
@@ -11,3 +11,7 @@ def get_path():
 
 def setup(app):
     app.add_html_theme('mxtheme', package_dir)
+    return {
+        'version': __version__,
+        'parallel_read_safe': True
+    }


### PR DESCRIPTION
Signed-off-by: Sheng Zha <zhasheng@amazon.com>

In apache/incubator-mxnet#19873 I'm getting a warning that the plugin mxtheme doesn't declare whether it's safe for parallel read. It needs to be set explicitly to get rid of the warning.

See: https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata